### PR TITLE
Use `map` for better codegen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,11 @@ pub fn is_id_start(ch: char) -> bool {
 /// Check unicode only for id_start
 #[inline]
 pub fn is_id_start_unicode(ch: char) -> bool {
-    let chunk = *TRIE_START.0.get(ch as usize / 8 / CHUNK).unwrap_or(&0);
+    let chunk = *TRIE_START
+        .0
+        .get(ch as usize / 8 / CHUNK)
+        .map(|v| *v)
+        .unwrap_or(0);
     let offset = chunk as usize * CHUNK / 2 + ch as usize / 8 % CHUNK;
     unsafe { LEAF.0.get_unchecked(offset) }.wrapping_shr(ch as u32 % 8) & 1 != 0
 }
@@ -282,7 +286,11 @@ pub fn is_id_continue(ch: char) -> bool {
 /// Check and unicode only for id_continue
 #[inline]
 pub fn is_id_continue_unicode(ch: char) -> bool {
-    let chunk = *TRIE_CONTINUE.0.get(ch as usize / 8 / CHUNK).unwrap_or(&0);
+    let chunk = *TRIE_CONTINUE
+        .0
+        .get(ch as usize / 8 / CHUNK)
+        .map(|v| *v)
+        .unwrap_or(0);
     let offset = chunk as usize * CHUNK / 2 + ch as usize / 8 % CHUNK;
     unsafe { LEAF.0.get_unchecked(offset) }.wrapping_shr(ch as u32 % 8) & 1 != 0
 }


### PR DESCRIPTION
See https://godbolt.org/z/W1Gbnfjz9 and https://godbolt.org/z/h8KjPnbPe.
Seems that compiler didn't optimize out the reference of literal even it is dereferenced immediately.