### PR TITLE
chore(unicode-id-start): exclude extraneous files from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["unicode", "id"]
 license = "(MIT OR Apache-2.0) AND Unicode-3.0"
 repository = "https://github.com/Boshen/unicode-id-start"
 rust-version = "1.31"
+include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dev-dependencies]
 criterion = { version = "0.8", default-features = false }


### PR DESCRIPTION
Adds explicit includes for `unicode-id-start` to omit 211.0 kB of files (67% of total) under `/tests`, `/benches`, and `.github` from the published package

Files removed from the package, by directory:

| Directory | Size | Files |
|---|---|---|
| `tests/**` (incl. 142 kB of `.fst` binaries) | 199.5 kB | 10 |
| `.github/**` | 6.1 kB | 6 |
| `benches/**` | 4.0 kB | 1 |
| root docs (`SECURITY.md`, `MAINTENANCE.md`) | 0.8 kB | 3 |
| root config (`.clippy.toml`, `.rustfmt.toml`, `rust-toolchain.toml`, `.gitattributes`, `.gitignore`) | 0.5 kB | 5 |

Verified with publish dry run

Found with [cargo-diet](https://github.com/the-lean-crate/cargo-diet)
